### PR TITLE
#86dupq4zd Return an error if a Swagger schema has a "type" that is not one of the OpenAPI-defined types

### DIFF
--- a/lib/validation/constants.js
+++ b/lib/validation/constants.js
@@ -1,0 +1,5 @@
+const RECOGNIZED_SCHEMA_TYPES = ['array', 'boolean', 'file', 'integer', 'number', 'string', 'object'];
+
+module.exports = {
+  RECOGNIZED_SCHEMA_TYPES
+};

--- a/lib/validation/datatypes/helper.js
+++ b/lib/validation/datatypes/helper.js
@@ -1,7 +1,6 @@
 const _ = require('lodash');
 const {errorCodes, validationError} = require('../errors');
-
-module.exports = exports = {};
+const {RECOGNIZED_SCHEMA_TYPES} = require('../constants');
 
 /**
  * Used by the {@link Validation.Parameters} to indicate that a particular <tt>value</tt> passed validation.
@@ -16,7 +15,6 @@ module.exports = exports = {};
 function successReturn(value) {
   return [{value}];
 }
-exports.successReturn = successReturn;
 
 function isString(value) {
   return typeof value === 'string' || value instanceof String;
@@ -51,7 +49,7 @@ function validateExistence({schema, value, models, validationContext, validation
 }
 
 function schemaHasPrimitiveType(schema) {
-  return ['array', 'boolean', 'file', 'integer', 'number', 'string', 'object'].includes(schema.type);
+  return RECOGNIZED_SCHEMA_TYPES.includes(schema.type);
 }
 
 function resolveSchema({schema, models, validationContext, validationSettings}) {
@@ -64,13 +62,28 @@ function resolveSchema({schema, models, validationContext, validationSettings}) 
     return {schema, validationContext};
   }
 
+  if (!validationSettings.allowSchemasWithInvalidTypesAndTreatThemLikeRefs && schema.type && !schemaHasPrimitiveType(schema)) {
+    if (validationSettings.throwErrorsWhenSchemaIsInvalid) {
+      throw new Error(`Swagger schema is invalid: ${validationContext.formatModelPath()} has bad type "${schema.type}".  Allowed types are: ${RECOGNIZED_SCHEMA_TYPES.join(", ")}`);
+    } else {
+      return {
+        error: validationError({
+          code: errorCodes.SCHEMA_HAS_INVALID_TYPE,
+          schemaType: schema.type,
+          validationContext,
+          validationSettings
+        })
+      };
+    }
+  }
+
   // Legacy behaviour: The schema "type" may actually refer to another model, like a $ref
   const modelName = schema.$ref || schema.type;
   const schemaIsKnown = models.hasOwnProperty(modelName);
 
   if (!schemaIsKnown) {
     if (validationSettings.throwErrorsWhenSchemaIsInvalid) {
-      throw new Error(`Swagger schema is invalid: Unknown reference to model "${modelName}"`);
+      throw new Error(`Swagger schema is invalid: ${validationContext.formatModelPath()} contains unknown reference to model "${modelName}"`);
     } else {
       return {
         error: validationError({
@@ -83,12 +96,16 @@ function resolveSchema({schema, models, validationContext, validationSettings}) 
     }
   }
 
-  const {schema: resolvedSchema, validationContext: newValidationContext} = resolveSchema({
+  const {schema: resolvedSchema, validationContext: newValidationContext, error} = resolveSchema({
     schema: models[modelName],
     models,
     validationContext: validationContext.descendIntoModel(modelName),
     validationSettings
   });
+
+  if (error) {
+    return {error};
+  }
 
   return {
     schema: {
@@ -99,8 +116,10 @@ function resolveSchema({schema, models, validationContext, validationSettings}) 
   };
 }
 
-exports.isString = isString;
-exports.validateExistence = validateExistence;
-exports.validateNullability = validateNullability;
-exports.resolveSchema = resolveSchema;
-exports.schemaHasPrimitiveType = schemaHasPrimitiveType;
+module.exports = {
+  successReturn,
+  isString,
+  validateExistence,
+  validateNullability,
+  resolveSchema
+};

--- a/lib/validation/errors.js
+++ b/lib/validation/errors.js
@@ -1,6 +1,7 @@
 const util = require('node:util');
 const moment = require('moment');
 const {describeDataType, describeRepeatedItemsInArray, pluralize} = require('./formatting');
+const {RECOGNIZED_SCHEMA_TYPES} = require('./constants');
 
 const errorCodes = {
   VALUE_CANNOT_BE_NULL: 'VALUE_CANNOT_BE_NULL',
@@ -28,6 +29,7 @@ const errorCodes = {
   ARRAY_ITEMS_ARE_NOT_UNIQUE: 'ARRAY_ITEMS_ARE_NOT_UNIQUE',
   OBJECT_CONTAINS_INVALID_PROPERTIES: 'OBJECT_CONTAINS_INVALID_PROPERTIES',
   SCHEMA_REFERENCES_UNKNOWN_MODEL: 'SCHEMA_REFERENCE_UNKNOWN_MODEL',
+  SCHEMA_HAS_INVALID_TYPE: 'SCHEMA_HAS_INVALID_TYPE',
   SCHEMA_CONTAINS_BAD_REGULAR_EXPRESSION: 'SCHEMA_CONTAINS_BAD_REGULAR_EXPRESSION',
 };
 
@@ -37,9 +39,11 @@ function getLegacyErrorMessage(errorCode, stringTemplateParams) {
     threshold,
     pattern,
     dataType,
+    schemaType,
     format,
     modelName,
-    disallowedProperties
+    disallowedProperties,
+    validationContext
   } = stringTemplateParams;
 
   switch (errorCode) {
@@ -89,6 +93,8 @@ function getLegacyErrorMessage(errorCode, stringTemplateParams) {
       return `${propertyName ?? 'object'} contains invalid properties: ${disallowedProperties.join(", ")}`
     case errorCodes.SCHEMA_REFERENCES_UNKNOWN_MODEL:
       return `Unknown param type ${modelName}`;
+    case errorCodes.SCHEMA_HAS_INVALID_TYPE:
+      return `Swagger schema is invalid: ${validationContext.formatModelPath()} has bad type "${schemaType}".  Allowed types are: ${RECOGNIZED_SCHEMA_TYPES.join(", ")}`;
     case errorCodes.SCHEMA_CONTAINS_BAD_REGULAR_EXPRESSION:
       return `${propertyName} is specified with an invalid pattern ${util.inspect(pattern)}`;
     default:
@@ -102,6 +108,7 @@ function getErrorMessage(errorCode, stringTemplateParams) {
     threshold,
     pattern,
     format,
+    schemaType,
     disallowedProperties,
     modelName,
     validationContext
@@ -157,7 +164,9 @@ function getErrorMessage(errorCode, stringTemplateParams) {
     case errorCodes.OBJECT_CONTAINS_INVALID_PROPERTIES:
       return `${validationContext.formatDataSource()} is invalid: ${validationContext.formatDataPath() || validationContext.formatDataSource().toLowerCase()} contains unrecognized ${disallowedProperties.length > 1 ? 'properties' : 'property'} ${disallowedProperties.map(property => `"${property}"`).join(', ')}`;
     case errorCodes.SCHEMA_REFERENCES_UNKNOWN_MODEL:
-      return `Swagger schema is invalid: unknown reference to model "${modelName}"`;
+      return `Swagger schema is invalid: ${validationContext.formatModelPath()} contains unknown reference to model "${modelName}"`;
+    case errorCodes.SCHEMA_HAS_INVALID_TYPE:
+      return `Swagger schema is invalid: ${validationContext.formatModelPath()} has bad type "${schemaType}".  Allowed types are: ${RECOGNIZED_SCHEMA_TYPES.join(", ")}`;
     case errorCodes.SCHEMA_CONTAINS_BAD_REGULAR_EXPRESSION:
       return `Swagger schema is invalid: bad regular expression "${util.inspect(pattern)}".  Regular expressions must be provided as a string, and must have correct syntax`
     default:

--- a/lib/validation/parameter.js
+++ b/lib/validation/parameter.js
@@ -1,8 +1,6 @@
 /** @namespace Validation */
 const datatypeValidators = require('./datatypes');
-const helper = require('./datatypes/helper');
-const {successReturn} = require("./datatypes/helper");
-const {validateNullability, validateExistence, resolveSchema} = helper;
+const {validateNullability, validateExistence, resolveSchema, successReturn} = require('./datatypes/helper');
 
 function selectValidationFunction(schema) {
   switch (schema.type?.toLowerCase()) {

--- a/lib/validation/requestParameters/body.js
+++ b/lib/validation/requestParameters/body.js
@@ -23,8 +23,15 @@ function validateRequestBody({schema, req, models, validationContext, validation
     value = bodyContainsParameter ? req.body[schema.name] : _.isEmpty(req.body) ? undefined : req.body;
   }
 
+  // OpenAPI v2 allows you to declare the body's schema in the "schema" property.
+  // OpenAPI v3 handles request body schemas differently, and this code would need to be changed to support the v3 spec
+  const schemaForBody = {
+    ...(schema.schema ?? schema),
+    name: schema.name
+  };
+
   const validationResult = validateParameter({
-    schema,
+    schema: schemaForBody,
     value,
     isRequired: true, // Per the OpenAPI spec, a body parameter is always required when it is present
     models,

--- a/lib/validation/validationContext.js
+++ b/lib/validation/validationContext.js
@@ -45,6 +45,9 @@ class ValidationContext {
   }
 
   formatModelPath() {
+    if (this.modelPath.length === 0) {
+      return 'Schema';
+    }
     return this.modelPath.join(' → ');
   }
 

--- a/lib/validation/validationSettings.js
+++ b/lib/validation/validationSettings.js
@@ -14,6 +14,7 @@ function getValidationSettings(validationSettings = {}) {
     allowNumbersToBeStrings: validationSettings.allowNumbersToBeStrings ?? true,
     allowNumberFormatsWithNoEquivalentRepresentationInJavascript: validationSettings.allowNumberFormatsWithNoEquivalentRepresentationInJavascript ?? true,
     allowStringsToHaveUnreliableDateFormat: validationSettings.allowStringsToHaveUnreliableDateFormat ?? true,
+    allowSchemasWithInvalidTypesAndTreatThemLikeRefs: validationSettings.allowSchemasWithInvalidTypesAndTreatThemLikeRefs ?? true,
     improvedErrorMessages: validationSettings.improvedErrorMessages ?? false,
   };
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swagger-validation",
-  "version": "9.1.0",
+  "version": "9.2.0",
   "author": {
     "name": "Wonderlic, Inc.",
     "email": "SoftwareDevelopment@wonderlic.com",

--- a/test/array.tests.js
+++ b/test/array.tests.js
@@ -690,7 +690,9 @@ describe('array', function () {
           TestArrayItem: {
             type: 'object',
             properties: {
-              someString: {type: 'string'},
+              someString: {
+                type: 'string'
+              },
             }
           }
         };
@@ -761,12 +763,12 @@ describe('array', function () {
     it('should allow empty strings to exist in an array which does not contain strings (legacy behaviour - this is a bug which is intentionally left in the code to avoid changing existing behaviour)', () => {
       const result = validateParameter({
         schema: models.TestArray,
-        value: [1, 2, ''],
+        value: [1, 2, '', 4, 5],
         models,
         validationContext,
         validationSettings
       });
-      assertValidationPassed(result);
+      assertValidationPassed(result, [[1, 2, '', 4, 5]]);
     });
 
     describe('when the validation settings specify that empty strings are not treated the same as undefined values', () => {

--- a/test/object.tests.js
+++ b/test/object.tests.js
@@ -2603,7 +2603,7 @@ describe('object', () => {
           models: {},
           validationContext,
           validationSettings
-        })).to.throw('Swagger schema is invalid: Unknown reference to model "SomeUnknownModel"');
+        })).to.throw('Swagger schema is invalid: Schema contains unknown reference to model "SomeUnknownModel"');
       });
 
       it('should throw an error when the object has a "type" that refers to an unknown model when the "type" field is used like a "$ref" pointing to another model (legacy behaviour)', () => {
@@ -2615,7 +2615,7 @@ describe('object', () => {
           models: {},
           validationContext,
           validationSettings
-        })).to.throw('Swagger schema is invalid: Unknown reference to model "SomeUnknownModel"');
+        })).to.throw('Swagger schema is invalid: Schema contains unknown reference to model "SomeUnknownModel"');
       });
     });
   });


### PR DESCRIPTION
Previously, the `swagger-validation` library allowed you to declare a `type` for a schema that acted like a `$ref`, and pointed to another model:

```javascript
const models = {

  RequestBody: {
    type: 'SomeOtherModel'
  },
  
  SomeOtherModel: {
    type: 'object',
    properties: {
      someProperty: {
        type: 'string'
      }
    }
  }
};
```

This is not an allowed use of the `type` field in OpenAPI v2 schemas.  This commit introduces a flag which, when enabled,  will cause the schema validator to throw an error when an invalid `type` is encountered.